### PR TITLE
added a package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,55 @@
+{
+    "name": "wtfgenes",
+    "version": "0.0.1",
+    "description": "Determines the function of a set of genes using MCMC term enrichment.",
+    "keywords": [
+        "node",
+        "bioinformatics",
+        "probabilistic modeling",
+        "MCMC",
+        "Term enrichment",
+        "Gene Ontology",
+        "GO",
+        "math",
+        "mathematics",
+        "graph"
+    ],
+    "author": "Ian Holmes <ihh@berkeley.edu>",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/ihh/wtfgenes.git"
+    },
+    "dependencies": {
+        "node-getopt": "*",
+        "mersennetwister": "*",
+        "jStat": "*"
+    },
+    "devDependencies": {
+        "chai": "^2.3.0",
+        "del": "^1.1.1",
+        "gulp": "^3.8.11",
+        "gulp-bump": "^0.3.0",
+        "gulp-git": "^1.2.3",
+        "gulp-jsdoc": "^0.1.4",
+        "gulp-mocha": "^2.0.1",
+        "gulp-pandoc": "^0.2.1",
+        "gulp-rename": "^1.2.2",
+        "gulp-shell": "^0.4.2",
+        "gulp-uglify": "^1.2.0",
+        "jsdoc": "^3.3.0",
+        "jsdoc-baseline": "git://github.com/hegemonic/jsdoc-baseline.git#74d1dc8075"
+    },
+    "bundleDependencies": [],
+    "private": false,
+    "directories": {
+        "perl": "perl",
+        "test": "test"
+    },
+    "main": "wtfgenes.js",
+    "bugs": {
+        "url": "https://github.com/ihh/wtfgenes/issues"
+    },
+    "scripts": {
+        "update-docs": "git checkout gh-pages && git pull && git merge master && gulp doc && git commit -a -m 'bump docs' && git push && git checkout master"
+    }
+}


### PR DESCRIPTION
- still needs a license field
- the devDependencies is copied from a bbop package.json, can be ignored but may be useful later
- same with the update-docs target
