### PR TITLE
Exclude protein complexes

### DIFF
--- a/bin/scrape-gaf.js
+++ b/bin/scrape-gaf.js
@@ -52,7 +52,7 @@ init_promise
     var resources = metadata.resources
     return Promise.all
     (resources
-     .filter (resource => !skip_id[resource.id])
+     .filter (resource => !skip_id[resource.id] && resource.id.indexOf("_complex") == -1)
      .map (function (resource) {
        var gaf_filename = resource.gaf_filename
        var gaf_url = gaf_url_prefix + gaf_filename


### PR DESCRIPTION
the foo_complex files are annotations to protein complexes. Using these in MGSA is intriguing but will require updates to the model